### PR TITLE
[Feat] #61 - EssentialInfoView에서 주변시설 불러오기 기능 구현

### DIFF
--- a/ZipZipSa/ZipZipSa/Presentation/EssentialInformation/EssentialInfoView.swift
+++ b/ZipZipSa/ZipZipSa/Presentation/EssentialInformation/EssentialInfoView.swift
@@ -36,6 +36,8 @@ struct EssentialInfoView: View {
     
     @State private var moveToChecklistView: Bool = false
     
+    @State private var availableFacilities: [Facility] = []
+    
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -60,6 +62,10 @@ struct EssentialInfoView: View {
                 ZZSMainButton(
                     action: {
                         moveToChecklistView = true
+                        Task {
+                            await searchNearbyFacilities()
+                            print(availableFacilities)
+                        }
                     },
                     text: "다음"
                 )
@@ -606,6 +612,21 @@ private extension EssentialInfoView {
         } catch {
             print("주소 변환 실패: \(error.localizedDescription)")
             print("Error occurred: \(error)")
+        }
+    }
+    
+    private func searchNearbyFacilities() async {
+        do {
+            let location = CLLocationCoordinate2D(latitude: selectedCoordinates?.latitude ?? 0.0, longitude: selectedCoordinates?.longitude ?? 0.0)
+            let results = try await FacilityChecker.shared.checkFacilities(at: location, for: Facility.allCases.map { $0.rawValue })
+            
+            availableFacilities = Facility.allCases.filter { facility in
+                results[facility.rawValue] == true
+            }
+        } catch let networkError as NetworkError {
+            networkError.logError()
+        } catch {
+            print("Unexpected error: \(error)")
         }
     }
 }

--- a/ZipZipSa/ZipZipSa/Presentation/EssentialInformation/EssentialInfoView.swift
+++ b/ZipZipSa/ZipZipSa/Presentation/EssentialInformation/EssentialInfoView.swift
@@ -616,17 +616,21 @@ private extension EssentialInfoView {
     }
     
     private func searchNearbyFacilities() async {
-        do {
-            let location = CLLocationCoordinate2D(latitude: selectedCoordinates?.latitude ?? 0.0, longitude: selectedCoordinates?.longitude ?? 0.0)
-            let results = try await FacilityChecker.shared.checkFacilities(at: location, for: Facility.allCases.map { $0.rawValue })
-            
-            availableFacilities = Facility.allCases.filter { facility in
-                results[facility.rawValue] == true
+        if let coordinates = selectedCoordinates {
+            do {
+                let location = CLLocationCoordinate2D(latitude: coordinates.latitude, longitude: coordinates.longitude)
+                let results = try await FacilityChecker.shared.checkFacilities(at: location, for: Facility.allCases.map { $0.rawValue })
+                
+                availableFacilities = Facility.allCases.filter { facility in
+                    results[facility.rawValue] == true
+                }
+            } catch let networkError as NetworkError {
+                networkError.logError()
+            } catch {
+                print("Unexpected error: \(error)")
             }
-        } catch let networkError as NetworkError {
-            networkError.logError()
-        } catch {
-            print("Unexpected error: \(error)")
+        } else {
+            availableFacilities = []
         }
     }
 }


### PR DESCRIPTION
close #61 

## *⛳️ Work Description*
- EssentialInfoView에서 선택한 주소를 기준으로 350m 반경 안에 있는 시설을 availableFacilities에 저장했습니다.
- selectedCoordinates가 nil일 경우 빈 배열을 반환하도록 옵셔널 처리를 했습니다.

## *📸 Screenshot*
| C5 기준 주변시설 불러오기 |
| -- |
| ![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-10-05 at 17 07 43](https://github.com/user-attachments/assets/ce33ed27-1e96-439b-b734-81697fb24525) |


## *📢 To Reviewers*
-

## *✅ Checklist*
- [ ] 주석 및 프린트문 제거 확인.
- [ ] 컨벤션 준수 확인.
