### PR TITLE
[Fix] #115 - 시트 충돌로 공유하기 버튼 작동 오류 수정

### DIFF
--- a/ZipZipSa/ZipZipSa/Presentation/HomeList/HomeListView.swift
+++ b/ZipZipSa/ZipZipSa/Presentation/HomeList/HomeListView.swift
@@ -12,14 +12,14 @@ struct HomeListView: View {
     @Query var homes: [HomeData]
     @Environment(\.modelContext) private var modelContext
     
+    @State private var selectedHome: HomeData = HomeData()
     @State private var showHomeHuntSheet = false
     @State private var showHomeResultCardSheet = false
-    @State private var selectedHome: HomeData = HomeData()
-    @State private var isDeleting: Bool = false
+    @State private var showDeleteActionSheet: Bool = false
     @State private var deleteTargetHomeData: HomeData?
     
     var body: some View {
-        ZStack{
+        ZStack {
             Color.Background.primary
                 .ignoresSafeArea()
             
@@ -37,17 +37,18 @@ struct HomeListView: View {
                     .scrollIndicators(.hidden)
                 }
             }
-            .sheet(isPresented: $showHomeResultCardSheet, content: {
-                ResultCardSheetView(homeData: $selectedHome)
-                    .presentationDragIndicator(.visible)
-            })
+            
         }
-        .confirmationDialog("이 항목이 삭제됩니다.", isPresented: $isDeleting, titleVisibility: .visible) {
+        .accentColor(Color.Button.tertiary)
+        .confirmationDialog("이 항목이 삭제됩니다.", isPresented: $showDeleteActionSheet, titleVisibility: .visible) {
             Button("삭제", role: .destructive) {
                 if let deleteTargetHomeData { modelContext.delete(deleteTargetHomeData) }
             }
         }
-        .accentColor(Color.Button.tertiary)
+        .sheet(isPresented: $showHomeResultCardSheet) {
+            ResultCardSheetView(homeData: $selectedHome)
+                .presentationDragIndicator(.visible)
+        }
         .fullScreenCover(isPresented: $showHomeHuntSheet) {
             EssentialInfoView(showHomeHuntSheet: $showHomeHuntSheet)
         }
@@ -138,7 +139,7 @@ private extension HomeListView {
     private func deleteHome(_ homeData: HomeData) {
         withAnimation {
             deleteTargetHomeData = homeData
-            isDeleting = true
+            showDeleteActionSheet = true
         }
     }
 }

--- a/ZipZipSa/ZipZipSa/Presentation/HomeList/HomeListView.swift
+++ b/ZipZipSa/ZipZipSa/Presentation/HomeList/HomeListView.swift
@@ -15,8 +15,6 @@ struct HomeListView: View {
     @State private var selectedHome: HomeData = HomeData()
     @State private var showHomeHuntSheet = false
     @State private var showHomeResultCardSheet = false
-    @State private var showDeleteActionSheet: Bool = false
-    @State private var deleteTargetHomeData: HomeData?
     
     var body: some View {
         ZStack {
@@ -40,11 +38,6 @@ struct HomeListView: View {
             
         }
         .accentColor(Color.Button.tertiary)
-        .confirmationDialog("이 항목이 삭제됩니다.", isPresented: $showDeleteActionSheet, titleVisibility: .visible) {
-            Button("삭제", role: .destructive) {
-                if let deleteTargetHomeData { modelContext.delete(deleteTargetHomeData) }
-            }
-        }
         .sheet(isPresented: $showHomeResultCardSheet) {
             ResultCardSheetView(homeData: $selectedHome)
                 .presentationDragIndicator(.visible)
@@ -138,8 +131,7 @@ private extension HomeListView {
     
     private func deleteHome(_ homeData: HomeData) {
         withAnimation {
-            deleteTargetHomeData = homeData
-            showDeleteActionSheet = true
+            modelContext.delete(homeData)
         }
     }
 }

--- a/ZipZipSa/ZipZipSa/Presentation/Main/MainView.swift
+++ b/ZipZipSa/ZipZipSa/Presentation/Main/MainView.swift
@@ -18,8 +18,6 @@ struct MainView: View {
     @State private var selectedHome: HomeData = HomeData()
     @State private var showHomeHuntSheet: Bool = false
     @State private var showHomeResultCardSheet = false
-    @State private var showDeleteActionSheet: Bool = false
-    @State private var deleteTargetHomeData: HomeData?
     
     var body: some View {
         NavigationStack {
@@ -45,14 +43,6 @@ struct MainView: View {
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .accentColor(Color.Button.tertiary)
         .navigationBarBackButtonHidden()
-        .confirmationDialog("이 항목이 삭제됩니다.", isPresented: $showDeleteActionSheet, titleVisibility: .visible) {
-            Button("삭제", role: .destructive) {
-                if let deleteTargetHomeData { modelContext.delete(deleteTargetHomeData)
-                }
-                showDeleteActionSheet = false
-                deleteTargetHomeData = nil
-            }
-        }
         .fullScreenCover(isPresented: $showHomeHuntSheet) {
             EssentialInfoView(showHomeHuntSheet: $showHomeHuntSheet)
         }
@@ -276,8 +266,7 @@ private extension MainView {
     
     private func deleteHome(_ homeData: HomeData) {
         withAnimation {
-            deleteTargetHomeData = homeData
-            showDeleteActionSheet = true
+            modelContext.delete(homeData)
         }
     }
 }

--- a/ZipZipSa/ZipZipSa/Presentation/Main/MainView.swift
+++ b/ZipZipSa/ZipZipSa/Presentation/Main/MainView.swift
@@ -15,10 +15,10 @@ struct MainView: View {
     
     @State private var currentTip = ZipZipSaTip.getRandomText()
     @State private var timer: Timer?
+    @State private var selectedHome: HomeData = HomeData()
     @State private var showHomeHuntSheet: Bool = false
     @State private var showHomeResultCardSheet = false
-    @State private var selectedHome: HomeData = HomeData()
-    @State private var isDeleting: Bool = false
+    @State private var showDeleteActionSheet: Bool = false
     @State private var deleteTargetHomeData: HomeData?
     
     var body: some View {
@@ -45,21 +45,21 @@ struct MainView: View {
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .accentColor(Color.Button.tertiary)
         .navigationBarBackButtonHidden()
-        .confirmationDialog("이 항목이 삭제됩니다.", isPresented: $isDeleting, titleVisibility: .visible) {
+        .confirmationDialog("이 항목이 삭제됩니다.", isPresented: $showDeleteActionSheet, titleVisibility: .visible) {
             Button("삭제", role: .destructive) {
                 if let deleteTargetHomeData { modelContext.delete(deleteTargetHomeData)
                 }
-                isDeleting = false
+                showDeleteActionSheet = false
                 deleteTargetHomeData = nil
             }
         }
         .fullScreenCover(isPresented: $showHomeHuntSheet) {
             EssentialInfoView(showHomeHuntSheet: $showHomeHuntSheet)
         }
-        .sheet(isPresented: $showHomeResultCardSheet, content: {
+        .sheet(isPresented: $showHomeResultCardSheet) {
             ResultCardSheetView(homeData: $selectedHome)
                 .presentationDragIndicator(.visible)
-        })
+        }
         .onAppear {
             print(users.count)
             print(users.first?.favoriteCategories.map{$0.text})
@@ -277,7 +277,7 @@ private extension MainView {
     private func deleteHome(_ homeData: HomeData) {
         withAnimation {
             deleteTargetHomeData = homeData
-            isDeleting = true
+            showDeleteActionSheet = true
         }
     }
 }

--- a/ZipZipSa/ZipZipSa/Presentation/Result/ResultCardView.swift
+++ b/ZipZipSa/ZipZipSa/Presentation/Result/ResultCardView.swift
@@ -96,8 +96,8 @@ private extension ResultCardView {
             DetailEssentialInfoView(homeData: $homeData)
         } label: {
             Text(ZipLiteral.ResultCard.resultDetailButtonText)
-                .foregroundStyle(.gray)
-                .font(Font.system(size: 16))
+                .foregroundStyle(Color.Text.tertiary)
+                .applyZZSFont(zzsFontSet: .bodyBold)
         }
         .padding(.bottom, 24)
     }
@@ -105,11 +105,12 @@ private extension ResultCardView {
     var ShareButton: some View {
         ShareLink(item: Image(uiImage: card), preview: SharePreview(ZipLiteral.ResultCard.sharePreviewText, icon: ZipLiteral.ResultCard.sharePreviewIcon)) {
             RoundedRectangle(cornerRadius: 15)
-                .foregroundStyle(.primary)
+                .foregroundStyle(Color.Button.primaryBlue)
                 .frame(height: 53)
                 .overlay(
                     Text(ZipLiteral.ResultCard.shareButtonText)
-                        .foregroundStyle(Color.white)
+                        .foregroundStyle(Color.Text.primary)
+                        .applyZZSFont(zzsFontSet: .bodyBold)
                 )
         }
         .padding(.horizontal, 16)

--- a/ZipZipSa/ZipZipSa/Presentation/ResultCardSheet/ResultCardSheet.swift
+++ b/ZipZipSa/ZipZipSa/Presentation/ResultCardSheet/ResultCardSheet.swift
@@ -71,8 +71,8 @@ private extension ResultCardSheetView {
             DetailEssentialInfoView(homeData: $homeData)
         } label: {
             Text(ZipLiteral.ResultCard.resultDetailButtonText)
-                .foregroundStyle(.gray)
-                .font(Font.system(size: 16))
+                .foregroundStyle(Color.Text.tertiary)
+                .applyZZSFont(zzsFontSet: .bodyBold)
         }
         .padding(.bottom, 24)
     }
@@ -80,11 +80,12 @@ private extension ResultCardSheetView {
     var ShareButton: some View {
         ShareLink(item: Image(uiImage: card), preview: SharePreview(ZipLiteral.ResultCard.sharePreviewText, icon: ZipLiteral.ResultCard.sharePreviewIcon)) {
             RoundedRectangle(cornerRadius: 15)
-                .foregroundStyle(.primary)
+                .foregroundStyle(Color.Button.primaryBlue)
                 .frame(height: 53)
                 .overlay(
                     Text(ZipLiteral.ResultCard.shareButtonText)
-                        .foregroundStyle(Color.white)
+                        .foregroundStyle(Color.Text.primary)
+                        .applyZZSFont(zzsFontSet: .bodyBold)
                 )
         }
         .padding(.horizontal, 16)


### PR DESCRIPTION
close #

## *⛳️ Work Description*
- 시트와 confirmationDialog의 충돌로, 공유하기 시트가 나타나지 않는 오류 해결
- confirmationDialog와 시트의 충돌, 프레젠테이션 방식을 하나만 지원하는 swiftUI의 자체적 문제로 해결 불가능이라 판단하고, 삭제 확인 과정을 제거하였다.

## *📸 Screenshot*


## *📢 To Reviewers*
-

## *✅ Checklist*
- [ ] 주석 및 프린트문 제거 확인.
- [ ] 컨벤션 준수 확인.
