### PR TITLE
[Release] 암호화 사용하지 않음을 info.plist에 명시하는 항목을 추가

### DIFF
--- a/ZipZipSa/ZipZipSa/Info.plist
+++ b/ZipZipSa/ZipZipSa/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
 	<key>UIAppFonts</key>


### PR DESCRIPTION
close #

## *⛳️ Work Description*
- 앱스토어 커넥트의 바뀐 정책에 따라 암호화 사용하지 않음을 명시

## *📸 Screenshot*


## *📢 To Reviewers*
-

## *✅ Checklist*
- [ ] 주석 및 프린트문 제거 확인.
- [ ] 컨벤션 준수 확인.
